### PR TITLE
setup.py fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
         'pytest>=7.4.3',
         'pytest-asyncio>=0.23.2',
         'python-Wappalyzer>=0.3.1'
+        'ptyhon-setuptools>=75.7.0'
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/19d1a60a-a403-4d67-9735-f6a48c9a7fd6)

아치 리눅스 venv 환경에서 pip install 로 설치시 pkg_resources라는 패키지가 누락된 것을 확인했습니다.
그래서 setup.py에 setuptools dependency를 추가했습니다.

**수정
requirements.txt에 setuptools가 포함된 것을 확인하였으나 왜 pip install에 누락됐는지 모르겠네요
