### PR TITLE
Handle FreecampDev false-positive floods

### DIFF
--- a/subsurfer/core/handler/passive/freecampdev.py
+++ b/subsurfer/core/handler/passive/freecampdev.py
@@ -14,6 +14,8 @@ console = Console()
 
 class FreecampDevScanner:
     """FreecampDev API를 통한 서브도메인 스캐너"""
+
+    MAX_SUBDOMAINS = 10000
     
     def __init__(self, domain: str, silent: bool = False):
         """
@@ -25,6 +27,27 @@ class FreecampDevScanner:
         self.base_url = "https://freecamp.dev/api/tools/network/subdomains/"
         self.subdomains = set()
         self.silent = silent
+
+    def _parse_results(self, json_content: str) -> Set[str]:
+        """응답 JSON에서 유효한 서브도메인만 추출한다."""
+        data = json.loads(json_content)
+        results = data.get("results", [])
+        found_subdomains = set()
+
+        for result in results:
+            subdomain = result.get("subdomain", "")
+            if subdomain and subdomain.endswith(f".{self.domain}"):
+                found_subdomains.add(subdomain.lower())
+
+        if len(found_subdomains) > self.MAX_SUBDOMAINS:
+            if not self.silent:
+                console.print(
+                    f"[yellow][!][/] FreecampDev 결과 {len(found_subdomains)}개 감지: "
+                    f"{self.MAX_SUBDOMAINS}개 초과로 FP로 판단하고 건너뜁니다"
+                )
+            return set()
+
+        return found_subdomains
         
     async def scan(self) -> Set[str]:
         """
@@ -48,14 +71,7 @@ class FreecampDevScanner:
                     
                     # JSON 파싱
                     try:
-                        data = json.loads(json_content)
-                        results = data.get("results", [])
-                        
-                        # 결과 처리
-                        for result in results:
-                            subdomain = result.get("subdomain", "")
-                            if subdomain and subdomain.endswith(f".{self.domain}"):
-                                self.subdomains.add(subdomain.lower())
+                        self.subdomains = self._parse_results(json_content)
                     except json.JSONDecodeError as e:
                         if not self.silent:
                             console.print(f"[bold red][-][/] JSON 파싱 오류: {str(e)}")

--- a/tests/handlers/test_freecampdev_scanner.py
+++ b/tests/handlers/test_freecampdev_scanner.py
@@ -1,0 +1,81 @@
+import json
+
+import pytest
+
+from subsurfer.core.handler.passive.freecampdev import FreecampDevScanner
+
+
+class MockResponse:
+    def __init__(self, status, text):
+        self.status = status
+        self._text = text
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    async def text(self):
+        return self._text
+
+
+class MockSession:
+    def __init__(self, response):
+        self.response = response
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    def post(self, *args, **kwargs):
+        return self.response
+
+
+@pytest.mark.asyncio
+async def test_freecampdev_scanner_returns_valid_results(monkeypatch):
+    domain = "example.com"
+    payload = json.dumps(
+        {
+            "results": [
+                {"subdomain": f"www.{domain}"},
+                {"subdomain": f"api.{domain}"},
+                {"subdomain": "invalid.test"},
+            ]
+        }
+    )
+
+    monkeypatch.setattr(
+        "subsurfer.core.handler.passive.freecampdev.aiohttp.ClientSession",
+        lambda: MockSession(MockResponse(200, payload)),
+    )
+
+    scanner = FreecampDevScanner(domain, silent=True)
+    results = await scanner.scan()
+
+    assert results == {f"www.{domain}", f"api.{domain}"}
+
+
+@pytest.mark.asyncio
+async def test_freecampdev_scanner_skips_false_positive_over_threshold(monkeypatch):
+    domain = "example.com"
+    payload = json.dumps(
+        {
+            "results": [
+                {"subdomain": f"sub{i}.{domain}"}
+                for i in range(FreecampDevScanner.MAX_SUBDOMAINS + 1)
+            ]
+        }
+    )
+
+    monkeypatch.setattr(
+        "subsurfer.core.handler.passive.freecampdev.aiohttp.ClientSession",
+        lambda: MockSession(MockResponse(200, payload)),
+    )
+
+    scanner = FreecampDevScanner(domain, silent=True)
+    results = await scanner.scan()
+
+    assert results == set()


### PR DESCRIPTION
가끔씩 일부 서브도메인에서 FreecampDev가 약 1만개의 False Positive가 발생합니다.

```
...
[*] FreecampDev Start Scan...
[+] FreecampDev Scan completed: 11282 found
...
```

이때 무의미한 도메인을 다시한번 검증하느라 시간 소모가 많이되어, FreecampDev에서 1만개 이상의 도메인이 수집되었다면 이를 False Positive로 간주하고 사용하지 않는 코드를 추가했습니다.